### PR TITLE
We are checking for the wrong object when being removed

### DIFF
--- a/src/Route.tsx
+++ b/src/Route.tsx
@@ -52,7 +52,7 @@ export class Route extends React.Component<RoutesProps, object> {
   public componentWillReceiveProps(nextProps: RoutesProps) {
     const { map, routesGroup } = this.context;
     // it's cheaper to remove and add instead of deep comparision
-    if (this.route) {
+    if (this.routeLine) {
       routesGroup.removeObject(this.routeLine);
     }
     this.addRouteToMap(nextProps.points)
@@ -61,7 +61,7 @@ export class Route extends React.Component<RoutesProps, object> {
   public componentWillUnmount() {
     const { map, routesGroup } = this.context;
 
-    if (this.route) {
+    if (this.routeLine) {
       routesGroup.removeObject(this.routeLine);
     }
   }


### PR DESCRIPTION
Related to: https://app.zenhub.com/workspaces/impargo-apps-5a72cce2203ff45b20d53add/issues/jlabeit/impargo-apps/1421 , app crashes because the Heremaps tries to remove an object which isn't present in the Array. Same as we do for Marker this does it for a Routepoint

Untested: Because I cannot get it to work locall