### PR TITLE
Enable bitmap update for markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@impargo/react-here-maps",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "React.js HERE Maps component",
   "main": "dist/main.js",
   "scripts": {

--- a/src/Marker.tsx
+++ b/src/Marker.tsx
@@ -75,6 +75,9 @@ export class Marker extends React.Component<MarkerProps, object> {
       ));
       this.marker.setIcon(getDomMarkerIcon(html));
     }
+    if(!nextChildProps && !childProps && (nextProps.bitmap)) {
+      this.marker.setIcon(getMarkerIcon(nextProps.bitmap))
+    }
     if (nextProps.data !== this.props.data) {
       this.marker.setData(nextProps.data);
     }


### PR DESCRIPTION
This is needed to enable non-dom markers to re-render icons on props update.